### PR TITLE
Add Plausible Analytics to the website

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "test": "echo \"No test script defined in package.json\"",
+    "build": "nvm install && nvm use && npm install && npm run build",
+    "launch": "nvm install && nvm use && npm install && echo \"NEXT_PUBLIC_SITE_URL=http://localhost:3000\\nNEXT_PUBLIC_OPENPANEL_CLIENT_ID=your_client_id\\nNEXT_PUBLIC_OPENPANEL_CLIENT_SECRET=your_client_secret\" > .env.local && npm run dev"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "tasks": {
-    "test": "echo \"No test script defined in package.json\"",
-    "build": "nvm install && nvm use && npm install && npm run build",
-    "launch": "nvm install && nvm use && npm install && echo \"NEXT_PUBLIC_SITE_URL=http://localhost:3000\\nNEXT_PUBLIC_OPENPANEL_CLIENT_ID=your_client_id\\nNEXT_PUBLIC_OPENPANEL_CLIENT_SECRET=your_client_secret\" > .env.local && npm run dev"
+    "build": "npm run build",
+    "launch": "npm run dev"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "sharp": "^0.33.5",
     "tailwind-merge": "^2.6.0",
     "vaul": "^1.1.2",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "next-plausible": "^4.0.0"
   },
   "devDependencies": {
     "@swc/helpers": "^0.5.15",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lucide-react": "^0.469.0",
     "marked": "^15.0.4",
     "next": "^15.1.3",
+    "next-plausible": "^3.12.4",
     "next-themes": "^0.4.4",
     "open-graph-scraper": "^6.8.3",
     "react": "^19.0.0",
@@ -50,8 +51,7 @@
     "sharp": "^0.33.5",
     "tailwind-merge": "^2.6.0",
     "vaul": "^1.1.2",
-    "zod": "^3.24.1",
-    "next-plausible": "^4.0.0"
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@swc/helpers": "^0.5.15",

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -3,6 +3,7 @@ import { Layout } from '../components/Layout'
 import { Toaster } from '../components/ui/toaster'
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { Analytics } from '@vercel/analytics/react'
+import PlausibleProvider from 'next-plausible'
 
 import './globals.css'
 
@@ -28,15 +29,20 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en" className="h-full antialiased" suppressHydrationWarning>
+      <head>
+        <script defer data-domain="jwe.in" src="https://plausible.io/js/script.outbound-links.pageview-props.tagged-events.js"></script>
+      </head>
       <body className="flex h-full bg-zinc-50 dark:bg-black" suppressHydrationWarning>
-        <ThemeProvider attribute="class" disableTransitionOnChange>
-          <div className="flex w-full">
-            <Layout>{children}</Layout>
-            <Toaster />
-          </div>
-        </ThemeProvider>
-        <SpeedInsights />
-        <Analytics />
+        <PlausibleProvider domain="jwe.in">
+          <ThemeProvider attribute="class" disableTransitionOnChange>
+            <div className="flex w-full">
+              <Layout>{children}</Layout>
+              <Toaster />
+            </div>
+          </ThemeProvider>
+          <SpeedInsights />
+          <Analytics />
+        </PlausibleProvider>
       </body>
     </html>
   )


### PR DESCRIPTION
Add Plausible analytics to the website.

* Import `PlausibleProvider` from `next-plausible` in `src/app/layout.jsx`.
* Wrap the `body` content with `PlausibleProvider` component and set the `domain` prop to `jwe.in`.
* Add a script tag in the `head` section to load Plausible analytics script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jweingardt12/jwe.in/pull/7?shareId=76c2a5f7-0346-41b3-aaf4-8e3cd73e64d9).