### PR TITLE
Fix typos

### DIFF
--- a/src/app/speaking/page.jsx
+++ b/src/app/speaking/page.jsx
@@ -47,7 +47,7 @@ export default function Speaking() {
           <Appearance
             href="#"
             title="Lessons learned from our first product recall"
-            description="They say that if you’re not embarassed by your first version, you’re doing it wrong. Well when you’re selling DIY space shuttle kits it turns out it’s a bit more complicated."
+            description="They say that if you’re not embarrassed by your first version, you’re doing it wrong. Well when you’re selling DIY space shuttle kits it turns out it’s a bit more complicated."
             event="Business of Startups 2020"
             cta="Watch video"
           />

--- a/src/app/work/page.jsx
+++ b/src/app/work/page.jsx
@@ -95,7 +95,7 @@ const testimonials = [
   [
     [
       {
-        body: 'Most PMs excel at strategy, but lack the execution muscle to make it all happen. Jason is the exception: he rolls up his sleeves and dives in regularly, and is constantly looking for ways to make our customers\' lives better. His curiousity and positivity is infectious, and it makes working with him genuinely fun.',
+        body: 'Most PMs excel at strategy, but lack the execution muscle to make it all happen. Jason is the exception: he rolls up his sleeves and dives in regularly, and is constantly looking for ways to make our customers\' lives better. His curiosity and positivity is infectious, and it makes working with him genuinely fun.',
         author: {
           name: 'Julia Gasboro',
           handle: 'Product Manager, CloudKitchens',
@@ -907,7 +907,7 @@ const WorkContent = () => {
                       className="col-span-1 md:col-span-2 rounded-2xl bg-white shadow-lg ring-1 ring-gray-900/5 dark:bg-zinc-900 dark:ring-white/10 flex flex-col transition duration-300 hover:scale-[1.02] hover:shadow-xl"
                     >
                       <blockquote className="p-6 text-sm text-gray-900 dark:text-white flex-grow">
-                        <p>{`"`}<span className="font-bold">Most PMs excel at strategy, but lack the execution muscle to make it all happen</span>{` Jason is the exception: he rolls up his sleeves and dives in regularly, and is constantly looking for ways to make our customers' lives better. His curiousity and positivity is infectious, and it makes working with him genuinely fun.`}</p>
+                        <p>{`"`}<span className="font-bold">Most PMs excel at strategy, but lack the execution muscle to make it all happen</span>{` Jason is the exception: he rolls up his sleeves and dives in regularly, and is constantly looking for ways to make our customers' lives better. His curiosity and positivity is infectious, and it makes working with him genuinely fun.`}</p>
                       </blockquote>
                       <figcaption className="flex items-center gap-x-4 border-t border-gray-900/10 dark:border-white/10 px-6 py-4 mt-auto">
                         <img 

--- a/src/app/work/page.jsx.bak
+++ b/src/app/work/page.jsx.bak
@@ -94,7 +94,7 @@ const testimonials = [
   [
     [
       {
-        body: 'Most PMs excel at strategy, but lack the execution muscle to make it all happen. Jason is the exception: he rolls up his sleeves and dives in regularly, and is constantly looking for ways to make our customers\' lives better. His curiousity and positivity is infectious, and it makes working with him genuinely fun.',
+        body: 'Most PMs excel at strategy, but lack the execution muscle to make it all happen. Jason is the exception: he rolls up his sleeves and dives in regularly, and is constantly looking for ways to make our customers\' lives better. His curiosity and positivity is infectious, and it makes working with him genuinely fun.',
         author: {
           name: 'Julia Gasboro',
           handle: 'Product Manager, CloudKitchens',


### PR DESCRIPTION
## Summary
- correct typos in testimonials and speaking page text

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442fba529083238c19e1e052104382